### PR TITLE
Updates for new eHST database model - May 2018

### DIFF
--- a/hsaquery/fetch.py
+++ b/hsaquery/fetch.py
@@ -2,11 +2,16 @@
 Fetch data directly from ESA Hubble Science Archive
 """
 
-DEFAULT_PRODUCTS = {'WFC3/IR':['RAW'],
-                    'WFPC2/WFPC2':['C0M','C1M'],
-                    'ACS/WFC':['FLC'],
-                    'WFC3/UVIS':['FLC']}
+# DEFAULT_PRODUCTS = {'WFC3-IR':['RAW'],
+#                     'WFPC2':['C0M','C1M'],
+#                     'ACS-WFC':['FLC'],
+#                     'WFC3-UVIS':['FLC']}
                     
+DEFAULT_PRODUCTS = {'IR':['RAW'],
+                    1:['C0M','C1M'],
+                    'WFC':['FLC'],
+                    'UVIS':['FLC']}
+                                        
 def make_curl_script(table, level=None, script_name=None, inst_products=DEFAULT_PRODUCTS, skip_existing=True, s3_sync=False, output_path='./'):
     """
     Generate a "curl" script to fetch products from the ESA HSA
@@ -36,7 +41,7 @@ def make_curl_script(table, level=None, script_name=None, inst_products=DEFAULT_
     import glob
     import os
     
-    BASE_URL = 'http://archives.esac.esa.int/ehst-sl-server/servlet/data-action?ARTIFACT_ID=' #J6FL25S4Q_RAW'
+    BASE_URL = 'http://archives.esac.esa.int/ehst-sl-server/servlet/data-action?ARTIFACT_ID=' #J6FL25S4Q_RAW.FITS'
     
     if s3_sync:
         # s3://stpubdata/hst/public/icwb/icwb1iu5q/icwb1iu5q_raw.fits    
@@ -46,7 +51,8 @@ def make_curl_script(table, level=None, script_name=None, inst_products=DEFAULT_
         # Get RAW for WFC3/IR, FLC for UVIS and ACS
         curl_list = []
         for i in range(len(table)):
-            inst_det = '{0}/{1}'.format(table['instrument'][i], table['detector'][i]) 
+            #inst_det = '{0}/{1}'.format(table['instrument'][i], table['detector'][i]) 
+            inst_det = table['detector'][i] #'{0}/{1}'.format(table['instrument'][i], table['detector'][i]) 
             
             if inst_det in inst_products:
                 products = inst_products[inst_det]
@@ -68,14 +74,14 @@ def make_curl_script(table, level=None, script_name=None, inst_products=DEFAULT_
                     if s3_sync:
                         curl_list.append(make_s3_command(dataset, product, output_path=output_path, s3_sync=s3_sync))                            
                     else:
-                        curl_list.append('curl {0}{1}_{2} -o {5}/{3}_{4}.fits.gz'.format(BASE_URL, dataset, product, dataset.lower(), product.lower(), output_path))
+                        curl_list.append('curl {0}{1}_{2}.FITS -o {5}/{3}_{4}.fits'.format(BASE_URL, dataset.upper(), product.upper(), dataset, product, output_path))
             
     else:
         if s3_sync:
             curl_list = [make_s3_command(dataset, product, output_path=output_path, s3_sync=s3_sync) for dataset in table['observation_id']]
                 
         else:
-            curl_list = ['curl {0}{1}_{2} -o {5}/{3}_{4}.fits.gz'.format(BASE_URL, dataset, level, dataset.lower(), level.lower(), output_path) for dataset in table['observation_id']]
+            curl_list = ['curl {0}{1}_{2}.FITS -o {5}/{3}_{4}.fits'.format(BASE_URL, dataset.upper(), level.upper(), dataset.lower(), level.lower(), output_path) for dataset in table['observation_id']]
     
     if script_name is not None:
         fp = open(script_name, 'w')

--- a/hsaquery/fetch.py
+++ b/hsaquery/fetch.py
@@ -7,10 +7,10 @@ Fetch data directly from ESA Hubble Science Archive
 #                     'ACS-WFC':['FLC'],
 #                     'WFC3-UVIS':['FLC']}
                     
-DEFAULT_PRODUCTS = {'IR':['RAW'],
-                    1:['C0M','C1M'],
-                    'WFC':['FLC'],
-                    'UVIS':['FLC']}
+DEFAULT_PRODUCTS = {'WFC3-IR':['RAW'],
+                    'WFPC2':['C0M','C1M'],
+                    'ACS-WFC':['FLC'],
+                    'WFC3-UVIS':['FLC']}
                                         
 def make_curl_script(table, level=None, script_name=None, inst_products=DEFAULT_PRODUCTS, skip_existing=True, s3_sync=False, output_path='./'):
     """
@@ -52,7 +52,7 @@ def make_curl_script(table, level=None, script_name=None, inst_products=DEFAULT_
         curl_list = []
         for i in range(len(table)):
             #inst_det = '{0}/{1}'.format(table['instrument'][i], table['detector'][i]) 
-            inst_det = table['detector'][i] #'{0}/{1}'.format(table['instrument'][i], table['detector'][i]) 
+            inst_det = table['instdet'][i] #'{0}/{1}'.format(table['instrument'][i], table['detector'][i]) 
             
             if inst_det in inst_products:
                 products = inst_products[inst_det]

--- a/hsaquery/overlaps.py
+++ b/hsaquery/overlaps.py
@@ -19,21 +19,21 @@ def test():
 
     
     # Example: high-z cluster pointings
-    tab = query.run_query(box=None, proposid=[14594], instruments=['WFC3', 'ACS'], extensions=['FLT'], filters=['G102','G141'], extra=[])
+    tab = query.run_query(box=None, proposid=[14594], instruments=['WFC3-IR', 'ACS-WFC'], extensions=['FLT'], filters=['G102','G141'], extra=[])
     
     # Ebeling
-    tab = query.run_query(box=None, proposid=[15132,14098,13671,12884,12166,11103,10875,], instruments=['WFC3'], extensions=['FLT'], filters=[], extra=[])
+    tab = query.run_query(box=None, proposid=[15132,14098,13671,12884,12166,11103,10875,], instruments=['WFC3-IR'], extensions=['FLT'], filters=[], extra=[])
     # Relics
-    tab = query.run_query(box=None, proposid=[14096], instruments=['WFC3'], extensions=['FLT'], filters=[], extra=[])
-    tab = query.run_query(box=None, proposid=[11591], instruments=['WFC3'], extensions=['FLT'], filters=[], extra=[])
-    tab = query.run_query(box=None, proposid=[13666,14148,14496], instruments=['WFC3'], extensions=['FLT'], filters=[], extra=[])
+    tab = query.run_query(box=None, proposid=[14096], instruments=['WFC3-IR'], extensions=['FLT'], filters=[], extra=[])
+    tab = query.run_query(box=None, proposid=[11591], instruments=['WFC3-iR'], extensions=['FLT'], filters=[], extra=[])
+    tab = query.run_query(box=None, proposid=[13666,14148,14496], instruments=['WFC3-IR'], extensions=['FLT'], filters=[], extra=[])
     tab = tab[tab['target'] != 'ANY']
     
     # MACS 0454
     box = [73.5462181, -3.0147200, 3]
-    tab = query.run_query(box=box, proposid=[], instruments=['WFC3', 'ACS'], extensions=['FLT'], filters=['F110W'], extra=[])
+    tab = query.run_query(box=box, proposid=[], instruments=['WFC3-IR', 'ACS-WFC'], extensions=['FLT'], filters=['F110W'], extra=[])
     
-def find_overlaps(tab, buffer_arcmin=1., filters=[], instruments=['WFC3', 'ACS'], proposid=[], SKIP=False, extra=query.DEFAULT_EXTRA, close=True):
+def find_overlaps(tab, buffer_arcmin=1., filters=[], instruments=['WFC3-IR', 'WFC3-UVIS', 'ACS-WFC'], proposid=[], SKIP=False, extra=query.DEFAULT_EXTRA, close=True):
     """
     Compute discrete groups from the parent table and find overlapping
     datasets.

--- a/hsaquery/overlaps.py
+++ b/hsaquery/overlaps.py
@@ -366,6 +366,9 @@ def parse_overlap_table(tab):
     names.append('NFILT')
     properties.append(len(np.unique(tab['filter'])))
     for c in ['filter', 'target', 'target_description', 'proposal_id']:
+        if c not in tab.colnames:
+            continue
+        
         names.append(c)
         properties.append(' '.join(['{0}'.format(p) for p in np.unique(tab[c])]))
         if c in ['target_description']:

--- a/hsaquery/query.py
+++ b/hsaquery/query.py
@@ -22,10 +22,10 @@ POSITION.GAL_LAT
 POSITION.GAL_LON
 POSITION.STC_S
 POSITION.FOV_SIZE
-POSITION.SPATIAL_RESOLUTION
 INSTRUMENT.INSTRUMENT_NAME
 DETECTOR.DETECTOR_NAME
-OPTICAL_ELEMENT.OPTICAL_ELEMENT_NAME
+ENERGY.FILTER
+ENERGY.BAND_NAME
 PROPOSAL.PROPOSAL_ID
 PROPOSAL.SCIENCE_CATEGORY
 PROPOSAL.PI_NAME
@@ -33,8 +33,43 @@ ARTIFACT.FILE_NAME
 ARTIFACT.FILE_EXTENSION
 """
 
-DEFAULT_RENAME = {'OPTICAL_ELEMENT_NAME':'FILTER', 'EXPOSURE_DURATION':'EXPTIME', 'INSTRUMENT_NAME':'INSTRUMENT', 'DETECTOR_NAME':'DETECTOR', 'STC_S':'FOOTPRINT', 'SPATIAL_RESOLUTION':'PIXSCALE', 'TARGET_NAME':'TARGET', 'SET_ID':'VISIT'}
+DEFAULT_FIELDS = """OBSERVATION
+TARGET.TARGET_NAME
+POSITION.RA
+POSITION.DEC
+POSITION.ECL_LAT
+POSITION.ECL_LON
+POSITION.GAL_LAT
+POSITION.GAL_LON
+POSITION.STC_S
+POSITION.STC_S_TAILORED
+POSITION.FOV_SIZE
+ENERGY.FILTER
+ENERGY.BAND_NAME
+PROPOSAL.PROPOSAL_ID
+PROPOSAL.SCIENCE_CATEGORY
+PROPOSAL.PI_NAME
+PROPOSAL.CYCLE
+ARTIFACT.ARTIFACT_ID
+ARTIFACT.FILE_EXTENSION
+ARTIFACT.FILE_PATH
+ARTIFACT.FILE_FORMAT
+"""
 
+# DEFAULT_RENAME = {'OPTICAL_ELEMENT_NAME':'FILTER',
+#                   'EXPOSURE_DURATION':'EXPTIME',
+#                   #'INSTRUMENT_NAME':'INSTRUMENT', 
+#                   #'DETECTOR_NAME':'DETECTOR', 
+#                   'STC_S':'FOOTPRINT', 
+#                   #'SPATIAL_RESOLUTION':'PIXSCALE', 
+#                   'TARGET_NAME':'TARGET', 
+#                   'SET_ID':'VISIT'}
+
+DEFAULT_RENAME = {'EXPOSURE_DURATION':'EXPTIME',
+                  'STC_S':'FOOTPRINT', 
+                  'TARGET_NAME':'TARGET', 
+                  'SET_ID':'VISIT'}
+                  
 DEFAULT_COLUMN_FORMAT = {'start_time_mjd':'.4f',
            'end_time_mjd':'.4f',
            'exptime':'.0f',
@@ -44,16 +79,21 @@ DEFAULT_COLUMN_FORMAT = {'start_time_mjd':'.4f',
            'ecl_lon':'.6f',
            'gal_lat':'.6f',
            'gal_lon':'.6f',
-           'fov_size':'.3f',
-           'pixscale':'.3f'}
+           'fov_size':'.3f'}#,
+           #'pixel_scale':'.3f'}
 
 # Don't get calibrations.  Can't use "INTENT LIKE 'SCIENCE'" because some 
 # science observations are flagged as 'Calibration' in the ESA HSA.
-DEFAULT_EXTRA = ["TARGET.TARGET_NAME NOT LIKE '{0}'".format(calib) 
-                 for calib in ['DARK','EARTH-CALIB', 'TUNGSTEN', 'BIAS',
-                               'DARK-EARTH-CALIB', 'DARK-NM', 'DEUTERIUM']]
+DEFAULT_EXTRA = ['ARTIFACT.FILE_FORMAT LIKE \'image/fits\' AND ARTIFACT.FILE_EXTENSION LIKE \'science\'']
 
-def run_query(box=None, proposid=[13871], instruments=['WFC3'], filters=[], extensions=['RAW','C1M'], extra=DEFAULT_EXTRA,  fields=','.join(DEFAULT_FIELDS.split()), maxitems=100000, rename_columns=DEFAULT_RENAME, lower=True, sort_column=['OBSERVATION_ID'], remove_tempfile=True):
+DEFAULT_EXTRA += ["TARGET.TARGET_NAME NOT LIKE '{0}'".format(calib) 
+                 for calib in ['DARK','EARTH-CALIB', 'TUNGSTEN', 'BIAS',
+                               'DARK-EARTH-CALIB', 'DARK-NM', 'DEUTERIUM',
+                               'INTFLAT', 'KSPOTS']]
+
+INSTRUMENT_DETECTORS = {'WFC3-UVIS':'UVIS', 'WFC3-IR':'IR', 'ACS-WFC':'WFC', 'ACS-HRC':'HRC', 'WFPC2':'1', 'STIS-NUV':'NUV-MAMA', 'STIS-ACQ':'CCD'}
+
+def run_query(box=None, proposid=[13871], instruments=['WFC3-IR'], filters=[], extensions=['RAW','C1M'], extra=DEFAULT_EXTRA,  fields=','.join(DEFAULT_FIELDS.split()), maxitems=100000, rename_columns=DEFAULT_RENAME, lower=True, sort_column=['OBSERVATION_ID'], remove_tempfile=True, get_query_string=False):
     """
     
     Optional position box query:
@@ -83,43 +123,99 @@ def run_query(box=None, proposid=[13871], instruments=['WFC3'], filters=[], exte
         qlist.append(bbox)
     
     if len(proposid) > 0:
-        pquery = ' OR '.join(['PROPOSAL.PROPOSAL_ID=={0}'.format(p) for p in proposid])
+        pquery = ' OR '.join(['PROPOSAL.PROPOSAL_ID LIKE \'{0}\''.format(p) for p in proposid])
         qlist.append('({0})'.format(pquery))
-    
-    if len(instruments) > 0:
-        iquery = ' OR '.join(['INSTRUMENT.INSTRUMENT_NAME LIKE \'{0}\''.format(p) for p in instruments])
-        qlist.append('({0})'.format(iquery))
-    
+        
     if len(filters) > 0:
-        fquery = ' OR '.join(['OPTICAL_ELEMENT.OPTICAL_ELEMENT_NAME LIKE \'{0}\''.format(p) for p in filters])
+        fquery = ' OR '.join(['ENERGY.FILTER LIKE \'{0}\''.format(p) for p in filters])
         qlist.append('({0})'.format(fquery))
     
-    if len(extensions) > 0:
-        equery = ' OR '.join(['ARTIFACT.FILE_EXTENSION LIKE \'{0}\''.format(p) for p in extensions])
-        qlist.append('({0})'.format(equery))
+    # if len(extensions) > 0:
+    #     equery = ' OR '.join(['ARTIFACT.FILE_EXTENSION LIKE \'{0}\''.format(p) for p in extensions])
+    #     qlist.append('({0})'.format(equery))
         
-    query = "http://archives.esac.esa.int/ehst-sl-server/servlet/metadata-action?RESOURCE_CLASS=OBSERVATION&QUERY=({0})&SELECTED_FIELDS={1}&PAGE=1&PAGE_SIZE={2}&RETURN_TYPE=CSV".format(' AND '.join(qlist+extra), fields, maxitems).replace(' ','%20')
+    query = "http://archives.esac.esa.int/ehst-sl-server/servlet/metadata-action?RESOURCE_CLASS=OBSERVATION&QUERY=({0})&SELECTED_FIELDS={1}&PAGE=1&PAGE_SIZE={2}&RETURN_TYPE=VOTable".format(' AND '.join(qlist+extra), fields, maxitems).replace(' ','%20')
+    if get_query_string:
+        return query
     
-    req = urllib.request.Request(query)
-    response = urllib.request.urlopen(req)
-    the_page = response.read().decode('utf-8')
     
-    if len(the_page) == 0:
-        print('Empty query: ')
-        print('\n', '\n '.join(qlist))
-        print('\n', fields)
-        return False
+    # req = urllib.request.Request(query)
+    # response = urllib.request.urlopen(req)
+    # the_page = response.read()#.decode('utf-8')
+    # 
+    # if len(the_page) == 0:
+    #     print('Empty query: ')
+    #     print('\n', '\n '.join(qlist))
+    #     print('\n', fields)
+    #     return False
         
     fp = tempfile.NamedTemporaryFile('w', delete=False)
-    fp.write(the_page.replace('"',''))
     fp.close()
 
-    tab = Table.read(fp.name, format='csv')
-
+    vo_tempfile = fp.name +'.votable'
+    os.system('wget \"'+query+'\" -O {0}'.format(vo_tempfile))
+    
+    lines = open(vo_tempfile).readlines()
+    lines[0] = lines[0].replace('eHST results', 'results')
+    
+    fp = open(vo_tempfile,'w')
+    fp.writelines(lines)
+    fp.close()
+    
+    # fp = open(vo_tempfile, 'w')
+    # fp.write(the_page.replace('"',''))
+    # fp.close()
+    
+    print('xxx', fp.name)
+    
+    tab = Table.read(vo_tempfile, format='votable')
+    
+    # Compute file extension
+    if 'ARTIFACT_ID' in tab.colnames:
+        file_extension = [str(file).split('_')[-1].split('.')[0].upper() for file in tab['ARTIFACT_ID']]
+    
+        tab['FILE_TYPE'] = file_extension
+        
+        if len(extensions) > 0:
+            ext_test = np.array([tab['FILE_TYPE'] == ext for ext in extensions]).sum(axis=0) > 0
+            tab = tab[ext_test]
+        
+    # Parse instrument configuration
+    if 'INSTRUMENT_CONFIGURATION' in tab.colnames:
+        aperture = [str(conf).split('|')[0].split('=')[1] for conf in tab['INSTRUMENT_CONFIGURATION']]
+        
+        config = {'APERTURE':[], 'DETECTOR':[], 'OBSMODE':[]}
+        for conf in tab['INSTRUMENT_CONFIGURATION']:
+            spl = conf.decode('utf-8').strip().split('|')
+            splk = {}
+            for item in spl:
+                k = item.split('=')
+                splk[k[0]] = k[1]
+                
+            for ck in config:
+                if ck in splk:
+                    config[ck].append(splk[ck])
+                else:
+                    config[ck].append('')
+        
+        for ck in config:
+            tab[ck] = config[ck]
+        
+        if len(instruments) > 0:
+            ins_test = np.array([tab['DETECTOR'] == INSTRUMENT_DETECTORS[ins] for ins in instruments]).sum(axis=0) > 0
+            tab = tab[ins_test]    
+        
+        swap_detector = {}
+        for k in INSTRUMENT_DETECTORS:
+            swap_detector[INSTRUMENT_DETECTORS[k]] = k
+        
+        instdet = [swap_detector[det] if det in swap_detector else '' for det in tab['DETECTOR']]
+        tab['INSTDET'] = instdet
+        
     if remove_tempfile:
-        os.unlink(fp.name)
+        os.unlink(vo_tempfile)
     else:
-        print('Temporary CSV file: ', fp.name)
+        print('Temporary VOTable file: ', vo_tempfile)
 
     # Sort
     tab.sort(sort_column)
@@ -128,6 +224,8 @@ def run_query(box=None, proposid=[13871], instruments=['WFC3'], filters=[], exte
     if 'RA' in tab.colnames:
         jtargname = [utils.radec_to_targname(ra=tab['RA'][i], dec=tab['DEC'][i], scl=6) for i in range(len(tab))]
         tab['JTARGNAME'] = jtargname
+    
+    fix_byte_columns(tab)
         
     for c in rename_columns:
         if c in tab.colnames:
@@ -137,9 +235,9 @@ def run_query(box=None, proposid=[13871], instruments=['WFC3'], filters=[], exte
         for c in tab.colnames:
             tab.rename_column(c, c.lower())
     
-    cols = tab.colnames
-    if ('instrument' in cols) & ('detector' in cols):
-        tab['instdet'] = ['{0}/{1}'.format(tab['instrument'][i], tab['detector'][i]) for i in range(len(tab))]
+    # cols = tab.colnames
+    # if ('instrument' in cols) & ('detector' in cols):
+    #     tab['instdet'] = ['{0}/{1}'.format(tab['instrument'][i], tab['detector'][i]) for i in range(len(tab))]
             
     #tab['OBSERVATION_ID','orientat'][so].show_in_browser(jsviewer=True)
     
@@ -147,6 +245,16 @@ def run_query(box=None, proposid=[13871], instruments=['WFC3'], filters=[], exte
     
     return tab
 
+def fix_byte_columns(tab):
+    for col in tab.colnames:
+        try:
+            if tab[col].dtype == np.dtype('O'):
+                strcol = [item.decode('utf-8') for item in tab[col]]
+                tab.remove_column(col)
+                tab[col] = strcol
+        except:
+            pass
+            
 def add_postcard(table, resolution=256):
     
    url = ['http://archives.esac.esa.int/ehst-sl-server/servlet/data-action?OBSERVATION_ID={0}&RETRIEVAL_TYPE=POSTCARD&RESOLUTION={1}'.format(o, resolution) for o in table['observation_id']]
@@ -160,15 +268,26 @@ def add_postcard(table, resolution=256):
        tab = grizli.utils.GTable(table)
        tab['observation_id','filter','orientat','postcard'][tab['visit'] == 1].write_sortable_html('tab.html', replace_braces=True, localhost=True, max_lines=10000, table_id=None, table_class='display compact', css=None)
         
+# def parse_polygons(polystr):
+#     if 'UNION' in polystr.upper():
+#         spl = polystr[:-1].split('Polygon')[1:]
+#     else:
+#         spl = polystr.replace('FK5','ICRS').split('ICRS')[1:]
+#         
+#     poly = [np.cast[float](p.split()).reshape((-1,2)) for p in spl]
+#     return poly
+
 def parse_polygons(polystr):
-    if 'UNION' in polystr.upper():
-        spl = polystr[:-1].split('Polygon')[1:]
+    if hasattr(polystr, 'decode'):
+        spl = polystr.decode('utf-8').strip()[1:-1].split(',')
     else:
-        spl = polystr.replace('FK5','ICRS').split('ICRS')[1:]
-        
-    poly = [np.cast[float](p.split()).reshape((-1,2)) for p in spl]
+        spl = polystr.strip()[1:-1].split(',')
+
+    poly = [np.cast[float](spl).reshape((-1,2))] #[np.cast[float](p.split()).reshape((-1,2)) for p in spl]
     return poly
-           
+    
+    
+
 def set_default_formats(table, formats=DEFAULT_COLUMN_FORMAT):
     """
     Set default print formats
@@ -182,8 +301,8 @@ def set_default_formats(table, formats=DEFAULT_COLUMN_FORMAT):
                'ecl_lon':'.6f',
                'gal_lat':'.6f',
                'gal_lon':'.6f',
-               'fov_size':'.3f',
-               'pixscale':'.3f'}
+               'fov_size':'.3f'}#,
+               #'pixscale':'.3f'}
     
     for f in formats:
         if f in table.colnames:

--- a/hsaquery/query.py
+++ b/hsaquery/query.py
@@ -65,7 +65,7 @@ ARTIFACT.FILE_FORMAT
 #                   'TARGET_NAME':'TARGET', 
 #                   'SET_ID':'VISIT'}
 
-DEFAULT_RENAME = {'EXPOSURE_DURATION':'EXPTIME',
+DEFAULT_RENAME = {'EXPOSURE_DURATION':'VISIT_DURATION',
                   'STC_S':'FOOTPRINT', 
                   'TARGET_NAME':'TARGET', 
                   'SET_ID':'VISIT'}
@@ -169,6 +169,7 @@ def run_query(box=None, proposid=[13871], instruments=['WFC3-IR'], filters=[], e
     print('xxx', fp.name)
     
     tab = Table.read(vo_tempfile, format='votable')
+    tab.meta['query'] = query, 'Query string'
     
     # Compute file extension
     if 'ARTIFACT_ID' in tab.colnames:
@@ -184,7 +185,7 @@ def run_query(box=None, proposid=[13871], instruments=['WFC3-IR'], filters=[], e
     if 'INSTRUMENT_CONFIGURATION' in tab.colnames:
         aperture = [str(conf).split('|')[0].split('=')[1] for conf in tab['INSTRUMENT_CONFIGURATION']]
         
-        config = {'APERTURE':[], 'DETECTOR':[], 'OBSMODE':[]}
+        config = {'APERTURE':[], 'DETECTOR':[], 'OBSMODE':[], 'EXPTIME':[]}
         for conf in tab['INSTRUMENT_CONFIGURATION']:
             spl = conf.decode('utf-8').strip().split('|')
             splk = {}
@@ -197,6 +198,8 @@ def run_query(box=None, proposid=[13871], instruments=['WFC3-IR'], filters=[], e
                     config[ck].append(splk[ck])
                 else:
                     config[ck].append('')
+        
+        config['EXPTIME'] = np.cast[float](config['EXPTIME'])
         
         for ck in config:
             tab[ck] = config[ck]

--- a/hsaquery/utils.py
+++ b/hsaquery/utils.py
@@ -1,6 +1,27 @@
 """
 Utilities
 """
+import os
+import warnings
+import numpy as np
+
+def set_warnings(numpy_level='ignore', astropy_level='ignore'):
+    """
+    Set global numpy and astropy warnings
+    
+    Parameters
+    ----------
+    numpy_level : {'ignore', 'warn', 'raise', 'call', 'print', 'log'}
+        Numpy error level (see `~numpy.seterr`).
+        
+    astropy_level : {'error', 'ignore', 'always', 'default', 'module', 'once'}
+        Astropy error level (see `~warnings.simplefilter`).
+    
+    """
+    from astropy.utils.exceptions import AstropyWarning
+    
+    np.seterr(all=numpy_level)
+    warnings.simplefilter(astropy_level, category=AstropyWarning)
 
 def radec_to_targname(ra=0, dec=0, scl=10000):
     """Turn decimal degree coordinates into a string

--- a/hsaquery/version.py
+++ b/hsaquery/version.py
@@ -1,2 +1,2 @@
 # git describe --tags
-__version__ = "0.1.6"
+__version__ = "0.1.6-3-ge2ee617"

--- a/hsaquery/version.py
+++ b/hsaquery/version.py
@@ -1,2 +1,2 @@
 # git describe --tags
-__version__ = "0.1.6-4-g081d2ea"
+__version__ = "0.1.6-6-g900af05"

--- a/hsaquery/version.py
+++ b/hsaquery/version.py
@@ -1,2 +1,2 @@
 # git describe --tags
-__version__ = "0.1.6-3-ge2ee617"
+__version__ = "0.1.6-4-g081d2ea"


### PR DESCRIPTION
The format of the ESA eHST database has changed as of mid-May 2018.   Some helpful database columns are now missing, but most of the information can be generated by parsing the query output.  

**NB**: There appears to be a bug in that the exposure-level integration times are incorrect and reflect the *total* integration time for the association containing a given exposure.